### PR TITLE
Fix for the onSearch event not triggering in RN V0.48.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ class MyScene extends PureComponent {
     /**
      * onSearch
      * return a Promise
+     * NOTE: As of RN V0.48.3 the blurOnSubmit property must be set to {true} for this to trigger
      */
     beforeSearch: PropTypes.func,
     onSearch: PropTypes.func,

--- a/index.js
+++ b/index.js
@@ -542,7 +542,7 @@ Search.propTypes = {
 
 Search.defaultProps = {
   editable: true,
-  blurOnSubmit: false,
+  blurOnSubmit: true,
   keyboardShouldPersist: false,
   searchIconCollapsedMargin: 25,
   searchIconExpandedMargin: 10,


### PR DESCRIPTION
Added a note in the readme and changed the default value of property blurOnSubmit to true.