### PR TITLE
Remove View.propTypes.style

### DIFF
--- a/index.js
+++ b/index.js
@@ -287,7 +287,6 @@ class Search extends PureComponent {
               shadowRadius: this.props.shadowRadius
             }
           ]}
-          onEndEditing={this.onCancel}
           editable={this.props.editable}
           value={this.state.keyword}
           onChangeText={this.onChangeText}

--- a/index.js
+++ b/index.js
@@ -498,11 +498,10 @@ Search.propTypes = {
     PropTypes.object,
     PropTypes.style
   ]),
-  cancelButtonStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
+  cancelButtonStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object, PropTypes.style]),
   onLayout: PropTypes.func,
-  cancelButtonStyle: PropTypes.style,
   cancelButtonTextStyle: Text.propTypes.style,
-  cancelButtonViewStyle: PropTypes.style,
+  cancelButtonViewStyle: PropTypes.oneOfType([PropTypes.object, PropTypes.style]),
 
   /**
      * text input

--- a/index.js
+++ b/index.js
@@ -496,13 +496,13 @@ Search.propTypes = {
   inputStyle: PropTypes.oneOfType([
     PropTypes.number,
     PropTypes.object,
-    View.propTypes.style
+    PropTypes.style
   ]),
   cancelButtonStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object]),
   onLayout: PropTypes.func,
-  cancelButtonStyle: View.propTypes.style,
+  cancelButtonStyle: PropTypes.style,
   cancelButtonTextStyle: Text.propTypes.style,
-  cancelButtonViewStyle: View.propTypes.style,
+  cancelButtonViewStyle: PropTypes.style,
 
   /**
      * text input


### PR DESCRIPTION
On Android using 6997d18 instead of the upstream master resolved a propTypes deprecation issue:

```
10-15 21:28:10.210 22933 22963 E AndroidRuntime: com.facebook.react.common.JavascriptException: undefined is not an object (evaluating 'l.View.propTypes.style'),
```

Would it not be worthwhile to apply this patch to the upstream?