### PR TITLE
Prevent invalid style to be applied to a View

### DIFF
--- a/index.js
+++ b/index.js
@@ -499,7 +499,7 @@ Search.propTypes = {
     View.propTypes.style,
     Text.propTypes.style
   ]),
-  cancelButtonStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object, View.propTypes.style, Text.propTypes.style]),
+  cancelButtonStyle: PropTypes.oneOfType([PropTypes.number, PropTypes.object, View.propTypes.style]),
   onLayout: PropTypes.func,
   cancelButtonTextStyle: Text.propTypes.style,
 


### PR DESCRIPTION
The cancelButtonStyle prop is shared between an Animated.View and a Text elements, since View can't take TextStylePropTypes cancelButtonStyle propTypes definition should only accept View.propTypes.style