### PR TITLE
Support defaultValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ class MyScene extends PureComponent {
     /**
      * text input
      */
+    defaultValue: PropTypes.string,
     placeholder: PropTypes.string,
     cancelTitle: PropTypes.oneOfType([
         PropTypes.string,

--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ class Search extends PureComponent {
     super(props);
 
     this.state = {
-      keyword: '',
+      keyword: props.defaultValue,
       expanded: false,
     };
     const { width } = Dimensions.get('window');
@@ -517,6 +517,7 @@ Search.propTypes = {
   /**
    * text input
    */
+  defaultValue: PropTypes.string,
   placeholder: PropTypes.string,
   cancelTitle: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   iconDelete: PropTypes.object,
@@ -556,6 +557,7 @@ Search.propTypes = {
 };
 
 Search.defaultProps = {
+  defaultValue: '',
   editable: true,
   blurOnSubmit: true,
   keyboardShouldPersist: false,


### PR DESCRIPTION
In order to support the following scenario:
the user searched and get some items as results; after he clicked to navigate to one of the items to check details, when he navigates back, it would be good if the search string (keyword) previously stored somewhere could be retrieved again and pre-filled in the search box by 'defaultValue' prop. 