### PR TITLE
Support focus when autoFocus prop updated

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,13 @@ class Search extends PureComponent {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if(!this.props.autoFocus && nextProps.autoFocus) {
+      this.setState({expanded: true})
+      this.refs.input_keyword._component.focus();
+    }
+  }
+
   onLayout = event => {
     const contentWidth = event.nativeEvent.layout.width;
     this.contentWidth = contentWidth;


### PR DESCRIPTION
When using react-navigation TabNavigator and using search box on a screen / its navbar which is the root route of one of the tabs, all the root route screens of the tabs have already mounted even if they are invisible right now. 
It means if the tab route is switched to, it can only achieve 'autoFocus' behaviour by catching up with componentWillReceiveProps instead of componentDidMount. 