### PR TITLE
Added search accessibility trait

### DIFF
--- a/index.js
+++ b/index.js
@@ -305,6 +305,7 @@ class Search extends PureComponent {
           autoCapitalize={this.props.autoCapitalize}
           onFocus={this.onFocus}
           underlineColorAndroid="transparent"
+          accessibilityTraits="search"
         />
         <TouchableWithoutFeedback onPress={this.onFocus}>
         {this.props.iconSearch


### PR DESCRIPTION
By adding an accessibility trait of "search" on the text input component, it is treated as a search field when using voiceover

https://facebook.github.io/react-native/docs/accessibility.html